### PR TITLE
Try to isolate debug mode perf regression

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,6 @@ thiserror = "1.0.19"
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+
+[profile.dev.package.backtrace]
+opt-level = 3

--- a/README.md
+++ b/README.md
@@ -54,6 +54,29 @@ eyre = "0.4"
 color-eyre = { version = "0.3", default-features = false }
 ```
 
+### Improving perf on debug builds
+
+In debug mode `color-eyre` behaves noticably worse than `eyre`. This is caused
+by the fact that `eyre` uses `std::backtrace::Backtrace` instead of
+`backtrace::Backtrace`. The std version of backtrace is precompiled with
+optimizations, this means that whether or not you're in debug mode doesn't
+matter much for how expensive backtrace capture is, it will always be in the
+10s of milliseconds to capture. A debug version of `backtrace::Backtrace`
+however isn't so lucky, and can take an order of magnitude more time to capture
+a backtrace compared to it's std counterpart.
+
+Cargo [profile
+overrides](https://doc.rust-lang.org/cargo/reference/profiles.html#overrides)
+can be used to mitigate this problem. By configuring your project to always
+build `backtrace` with optimizations you should get the same performance from
+`color-eyre` that you're used to with `eyre`. To do so add the following to
+your Cargo.toml:
+
+```toml
+[profile.dev.package.backtrace]
+opt-level = 3
+```
+
 ## Features
 
 ### Multiple report format verbosity levels

--- a/examples/debug_perf.rs
+++ b/examples/debug_perf.rs
@@ -1,17 +1,20 @@
 //! example for manually testing the perf of color-eyre in debug vs release
 
 use color_eyre::{Help, Report};
-use eyre::WrapErr;
-use tracing::{info, instrument};
+use eyre::{eyre, WrapErr};
+use tracing::instrument;
 
 #[instrument]
 fn main() -> Result<(), Report> {
     #[cfg(feature = "capture-spantrace")]
     install_tracing();
 
-    let report = read_config().unwrap_err();
-
     let start = std::time::Instant::now();
+    let report = Err::<(), Report>(eyre!("fake error"))
+        .wrap_err("wrapped error")
+        .suggestion("try using a file that exists next time")
+        .unwrap_err();
+
     let _ = format!("Error: {:?}", report);
     drop(report);
     let end = std::time::Instant::now();
@@ -37,17 +40,4 @@ fn install_tracing() {
         .with(fmt_layer)
         .with(ErrorLayer::default())
         .init();
-}
-
-#[instrument]
-fn read_file(path: &str) -> Result<(), Report> {
-    info!("Reading file");
-    Ok(std::fs::read_to_string(path).map(drop)?)
-}
-
-#[instrument]
-fn read_config() -> Result<(), Report> {
-    read_file("fake_file")
-        .wrap_err("Unable to read config")
-        .suggestion("try using a file that exists next time")
 }

--- a/examples/debug_perf.rs
+++ b/examples/debug_perf.rs
@@ -4,24 +4,33 @@ use color_eyre::{Help, Report};
 use eyre::{eyre, WrapErr};
 use tracing::instrument;
 
-#[instrument]
 fn main() -> Result<(), Report> {
     #[cfg(feature = "capture-spantrace")]
     install_tracing();
 
+    time_report();
+
+    Ok(())
+}
+
+#[instrument]
+fn time_report() {
+    time_report_inner()
+}
+
+#[instrument]
+fn time_report_inner() {
     let start = std::time::Instant::now();
     let report = Err::<(), Report>(eyre!("fake error"))
         .wrap_err("wrapped error")
         .suggestion("try using a file that exists next time")
         .unwrap_err();
 
-    let _ = format!("Error: {:?}", report);
+    let _ = println!("Error: {:?}", report);
     drop(report);
     let end = std::time::Instant::now();
 
     dbg!(end - start);
-
-    Ok(())
 }
 
 #[cfg(feature = "capture-spantrace")]

--- a/examples/debug_perf.rs
+++ b/examples/debug_perf.rs
@@ -1,0 +1,53 @@
+//! example for manually testing the perf of color-eyre in debug vs release
+
+use color_eyre::{Help, Report};
+use eyre::WrapErr;
+use tracing::{info, instrument};
+
+#[instrument]
+fn main() -> Result<(), Report> {
+    #[cfg(feature = "capture-spantrace")]
+    install_tracing();
+
+    let report = read_config().unwrap_err();
+
+    let start = std::time::Instant::now();
+    let _ = format!("Error: {:?}", report);
+    drop(report);
+    let end = std::time::Instant::now();
+
+    dbg!(end - start);
+
+    Ok(())
+}
+
+#[cfg(feature = "capture-spantrace")]
+fn install_tracing() {
+    use tracing_error::ErrorLayer;
+    use tracing_subscriber::prelude::*;
+    use tracing_subscriber::{fmt, EnvFilter};
+
+    let fmt_layer = fmt::layer().with_target(false);
+    let filter_layer = EnvFilter::try_from_default_env()
+        .or_else(|_| EnvFilter::try_new("info"))
+        .unwrap();
+
+    tracing_subscriber::registry()
+        .with(filter_layer)
+        .with(fmt_layer)
+        .with(ErrorLayer::default())
+        .init();
+}
+
+#[instrument]
+fn read_file(path: &str) -> Result<(), Report> {
+    info!("Reading file");
+    Ok(std::fs::read_to_string(path).map(drop)?)
+}
+
+#[instrument]
+fn read_config() -> Result<(), Report> {
+    read_file("fake_file")
+        .wrap_err("Unable to read config")
+        .suggestion("try using a file that exists next time")
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@
 //! and `Backtrace`, minimal, short, and full. Take the following example, taken from
 //! [`examples/usage.rs`]:
 //!
-//! ```rust
+//! ```rust,should_panic
 //! use color_eyre::{Help, Report};
 //! use eyre::WrapErr;
 //! use tracing::{info, instrument};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,29 @@
 //! color-eyre = { version = "0.3", default-features = false }
 //! ```
 //!
+//! ### Improving perf on debug builds
+//!
+//! In debug mode `color-eyre` behaves noticably worse than `eyre`. This is caused
+//! by the fact that `eyre` uses `std::backtrace::Backtrace` instead of
+//! `backtrace::Backtrace`. The std version of backtrace is precompiled with
+//! optimizations, this means that whether or not you're in debug mode doesn't
+//! matter much for how expensive backtrace capture is, it will always be in the
+//! 10s of milliseconds to capture. A debug version of `backtrace::Backtrace`
+//! however isn't so lucky, and can take an order of magnitude more time to capture
+//! a backtrace compared to it's std counterpart.
+//!
+//! Cargo [profile
+//! overrides](https://doc.rust-lang.org/cargo/reference/profiles.html#overrides)
+//! can be used to mitigate this problem. By configuring your project to always
+//! build `backtrace` with optimizations you should get the same performance from
+//! `color-eyre` that you're used to with `eyre`. To do so add the following to
+//! your Cargo.toml:
+//!
+//! ```toml
+//! [profile.dev.package.backtrace]
+//! opt-level = 3
+//! ```
+//!
 //! ## Features
 //!
 //! ### Multiple report format verbosity levels
@@ -49,7 +72,7 @@
 //! and `Backtrace`, minimal, short, and full. Take the following example, taken from
 //! [`examples/usage.rs`]:
 //!
-//! ```rust,should_panic
+//! ```rust
 //! use color_eyre::{Help, Report};
 //! use eyre::WrapErr;
 //! use tracing::{info, instrument};


### PR DESCRIPTION
fixes #19 

initial tests aren't reproducing the issue yet, we're seeing an 8x decrease in perf between debug and release but not 1000x and definitely not 3-5 second delays.

```
color-eyre/examples on  master [$?] via 🦀 v1.43.1 took 15s
❯ RUST_BACKTRACE=full cargo run --example debug_perf
   Compiling color-eyre v0.3.2 (/home/jlusby/git/rust/color-eyre)
    Finished dev [unoptimized + debuginfo] target(s) in 1.94s
     Running `/home/jlusby/git/rust/color-eyre/target/debug/examples/debug_perf`
May 25 10:46:20.784  INFO read_config:read_file{path="fake_file"}: Reading file
[examples/debug_perf.rs:19] end - start = 716.4µs

color-eyre/examples on  master [$?] via 🦀 v1.43.1 took 2s
❯ RUST_BACKTRACE=1 cargo run --example debug_perf
    Finished dev [unoptimized + debuginfo] target(s) in 0.03s
     Running `/home/jlusby/git/rust/color-eyre/target/debug/examples/debug_perf`
May 25 10:46:25.543  INFO read_config:read_file{path="fake_file"}: Reading file
[examples/debug_perf.rs:19] end - start = 552.331µs

color-eyre/examples on  master [$?] via 🦀 v1.43.1
❯ cargo run --example debug_perf
    Finished dev [unoptimized + debuginfo] target(s) in 0.04s
     Running `/home/jlusby/git/rust/color-eyre/target/debug/examples/debug_perf`
May 25 10:46:29.709  INFO read_config:read_file{path="fake_file"}: Reading file
[examples/debug_perf.rs:19] end - start = 154.044µs

color-eyre/examples on  master [$?] via 🦀 v1.43.1
❯ cargo run --example debug_perf --release
   Compiling color-eyre v0.3.2 (/home/jlusby/git/rust/color-eyre)
    Finished release [optimized] target(s) in 1.43s
     Running `/home/jlusby/git/rust/color-eyre/target/release/examples/debug_perf`
May 25 10:46:37.432  INFO read_config:read_file{path="fake_file"}: Reading file
[examples/debug_perf.rs:19] end - start = 24.35µs
```