### PR TITLE
Fix cleanup warnings in `tests/minimal.rs` when compiled for windows.

### DIFF
--- a/tests/minimal.rs
+++ b/tests/minimal.rs
@@ -71,11 +71,12 @@ fn read_config() -> Result<(), Report> {
 // Define at the bottom to prevent it from changing line numbers
 #[cfg(not(windows))]
 #[cfg(feature = "capture-spantrace")]
-static EXPECTED: &str = "Error: \n   0: \u{1b}[38;5;9mUnable to read config\u{1b}[0m\n   1: \u{1b}[38;5;9mNo such file or directory (os error 2)\u{1b}[0m\n\n  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ SPANTRACE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n  \n   0: \u{1b}[38;5;9mminimal\u{1b}[0m\u{1b}[38;5;9m::\u{1b}[0m\u{1b}[38;5;9mread_file\u{1b}[0m with \u{1b}[38;5;14mpath=\"fake_file\"\u{1b}[0m\n      at tests/minimal.rs:41\n   1: \u{1b}[38;5;9mminimal\u{1b}[0m\u{1b}[38;5;9m::\u{1b}[0m\u{1b}[38;5;9mread_config\u{1b}[0m\n      at tests/minimal.rs:47\n\n\u{1b}[38;5;14mSuggestion\u{1b}[0m: try using a file that exists next time";
+static EXPECTED: &str = "Error: \n   0: \u{1b}[38;5;9mUnable to read config\u{1b}[0m\n   1: \u{1b}[38;5;9mNo such file or directory (os error 2)\u{1b}[0m\n\n  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ SPANTRACE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n  \n   0: \u{1b}[38;5;9mminimal\u{1b}[0m\u{1b}[38;5;9m::\u{1b}[0m\u{1b}[38;5;9mread_file\u{1b}[0m with \u{1b}[38;5;14mpath=\"fake_file\"\u{1b}[0m\n      at tests/minimal.rs:58\n   1: \u{1b}[38;5;9mminimal\u{1b}[0m\u{1b}[38;5;9m::\u{1b}[0m\u{1b}[38;5;9mread_config\u{1b}[0m\n      at tests/minimal.rs:64\n\n\u{1b}[38;5;14mSuggestion\u{1b}[0m: try using a file that exists next time";
 
 #[cfg(not(feature = "capture-spantrace"))]
 static EXPECTED: &str = "Error: \n   0: \u{1b}[38;5;9mUnable to read config\u{1b}[0m\n   1: \u{1b}[38;5;9mNo such file or directory (os error 2)\u{1b}[0m\n\n\u{1b}[38;5;14mSuggestion\u{1b}[0m: try using a file that exists next time";
 
+#[cfg(windows)]
 #[cfg(feature = "capture-spantrace")]
 static WINDOWS_EXPECTED: &str = "Error: \n   0: \u{1b}[38;5;9mUnable to read config\u{1b}[0m\n   1: \u{1b}[38;5;9mThe system cannot find the file specified. (os error 2)\u{1b}[0m\n\n  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ SPANTRACE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n  \n   0: \u{1b}[38;5;9mminimal\u{1b}[0m\u{1b}[38;5;9m::\u{1b}[0m\u{1b}[38;5;9mread_file\u{1b}[0m with \u{1b}[38;5;14mpath=\"fake_file\"\u{1b}[0m\n      at tests\\minimal.rs:58\n   1: \u{1b}[38;5;9mminimal\u{1b}[0m\u{1b}[38;5;9m::\u{1b}[0m\u{1b}[38;5;9mread_config\u{1b}[0m\n      at tests\\minimal.rs:64\n\n\u{1b}[38;5;14mSuggestion\u{1b}[0m: try using a file that exists next time";
 

--- a/tests/minimal.rs
+++ b/tests/minimal.rs
@@ -20,6 +20,23 @@ fn minimal() -> Result<(), Report> {
     Ok(())
 }
 
+#[instrument]
+#[test]
+#[cfg(windows)]
+fn minimal() -> Result<(), Report> {
+    #[cfg(feature = "capture-spantrace")]
+    install_tracing();
+
+    let report = read_config().unwrap_err();
+    let report = format!("Error: {:?}", report);
+
+    println!("Expected\n{}", EXPECTED);
+    println!("Actual\n{}", report);
+    assert_eq!(WINDOWS_EXPECTED, report);
+
+    Ok(())
+}
+
 #[cfg(feature = "capture-spantrace")]
 fn install_tracing() {
     use tracing_error::ErrorLayer;
@@ -57,3 +74,9 @@ static EXPECTED: &str = "Error: \n   0: \u{1b}[38;5;9mUnable to read config\u{1b
 
 #[cfg(not(feature = "capture-spantrace"))]
 static EXPECTED: &str = "Error: \n   0: \u{1b}[38;5;9mUnable to read config\u{1b}[0m\n   1: \u{1b}[38;5;9mNo such file or directory (os error 2)\u{1b}[0m\n\n\u{1b}[38;5;14mSuggestion\u{1b}[0m: try using a file that exists next time";
+
+#[cfg(feature = "capture-spantrace")]
+static WINDOWS_EXPECTED: &str = "Error: \n   0: \u{1b}[38;5;9mUnable to read config\u{1b}[0m\n   1: \u{1b}[38;5;9mThe system cannot find the file specified. (os error 2)\u{1b}[0m\n\n  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ SPANTRACE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n  \n   0: \u{1b}[38;5;9mminimal\u{1b}[0m\u{1b}[38;5;9m::\u{1b}[0m\u{1b}[38;5;9mread_file\u{1b}[0m with \u{1b}[38;5;14mpath=\"fake_file\"\u{1b}[0m\n      at tests\\minimal.rs:58\n   1: \u{1b}[38;5;9mminimal\u{1b}[0m\u{1b}[38;5;9m::\u{1b}[0m\u{1b}[38;5;9mread_config\u{1b}[0m\n      at tests\\minimal.rs:64\n\n\u{1b}[38;5;14mSuggestion\u{1b}[0m: try using a file that exists next time";
+
+#[cfg(not(feature = "capture-spantrace"))]
+static WINDOWS_EXPECTED: &str = "Error: \n   0: \u{1b}[38;5;9mUnable to read config\u{1b}[0m\n   1: \u{1b}[38;5;9mThe system cannot find the file specified. (os error 2)\u{1b}[0m\n\n\u{1b}[38;5;14mSuggestion\u{1b}[0m: try using a file that exists next time";

--- a/tests/minimal.rs
+++ b/tests/minimal.rs
@@ -73,6 +73,7 @@ fn read_config() -> Result<(), Report> {
 #[cfg(feature = "capture-spantrace")]
 static EXPECTED: &str = "Error: \n   0: \u{1b}[38;5;9mUnable to read config\u{1b}[0m\n   1: \u{1b}[38;5;9mNo such file or directory (os error 2)\u{1b}[0m\n\n  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ SPANTRACE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n  \n   0: \u{1b}[38;5;9mminimal\u{1b}[0m\u{1b}[38;5;9m::\u{1b}[0m\u{1b}[38;5;9mread_file\u{1b}[0m with \u{1b}[38;5;14mpath=\"fake_file\"\u{1b}[0m\n      at tests/minimal.rs:58\n   1: \u{1b}[38;5;9mminimal\u{1b}[0m\u{1b}[38;5;9m::\u{1b}[0m\u{1b}[38;5;9mread_config\u{1b}[0m\n      at tests/minimal.rs:64\n\n\u{1b}[38;5;14mSuggestion\u{1b}[0m: try using a file that exists next time";
 
+#[cfg(not(windows))]
 #[cfg(not(feature = "capture-spantrace"))]
 static EXPECTED: &str = "Error: \n   0: \u{1b}[38;5;9mUnable to read config\u{1b}[0m\n   1: \u{1b}[38;5;9mNo such file or directory (os error 2)\u{1b}[0m\n\n\u{1b}[38;5;14mSuggestion\u{1b}[0m: try using a file that exists next time";
 
@@ -80,5 +81,6 @@ static EXPECTED: &str = "Error: \n   0: \u{1b}[38;5;9mUnable to read config\u{1b
 #[cfg(feature = "capture-spantrace")]
 static WINDOWS_EXPECTED: &str = "Error: \n   0: \u{1b}[38;5;9mUnable to read config\u{1b}[0m\n   1: \u{1b}[38;5;9mThe system cannot find the file specified. (os error 2)\u{1b}[0m\n\n  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ SPANTRACE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n  \n   0: \u{1b}[38;5;9mminimal\u{1b}[0m\u{1b}[38;5;9m::\u{1b}[0m\u{1b}[38;5;9mread_file\u{1b}[0m with \u{1b}[38;5;14mpath=\"fake_file\"\u{1b}[0m\n      at tests\\minimal.rs:58\n   1: \u{1b}[38;5;9mminimal\u{1b}[0m\u{1b}[38;5;9m::\u{1b}[0m\u{1b}[38;5;9mread_config\u{1b}[0m\n      at tests\\minimal.rs:64\n\n\u{1b}[38;5;14mSuggestion\u{1b}[0m: try using a file that exists next time";
 
+#[cfg(windows)]
 #[cfg(not(feature = "capture-spantrace"))]
 static WINDOWS_EXPECTED: &str = "Error: \n   0: \u{1b}[38;5;9mUnable to read config\u{1b}[0m\n   1: \u{1b}[38;5;9mThe system cannot find the file specified. (os error 2)\u{1b}[0m\n\n\u{1b}[38;5;14mSuggestion\u{1b}[0m: try using a file that exists next time";

--- a/tests/minimal.rs
+++ b/tests/minimal.rs
@@ -30,7 +30,7 @@ fn minimal() -> Result<(), Report> {
     let report = read_config().unwrap_err();
     let report = format!("Error: {:?}", report);
 
-    println!("Expected\n{}", EXPECTED);
+    println!("Expected\n{}", WINDOWS_EXPECTED);
     println!("Actual\n{}", report);
     assert_eq!(WINDOWS_EXPECTED, report);
 
@@ -69,6 +69,7 @@ fn read_config() -> Result<(), Report> {
 }
 
 // Define at the bottom to prevent it from changing line numbers
+#[cfg(not(windows))]
 #[cfg(feature = "capture-spantrace")]
 static EXPECTED: &str = "Error: \n   0: \u{1b}[38;5;9mUnable to read config\u{1b}[0m\n   1: \u{1b}[38;5;9mNo such file or directory (os error 2)\u{1b}[0m\n\n  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ SPANTRACE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n  \n   0: \u{1b}[38;5;9mminimal\u{1b}[0m\u{1b}[38;5;9m::\u{1b}[0m\u{1b}[38;5;9mread_file\u{1b}[0m with \u{1b}[38;5;14mpath=\"fake_file\"\u{1b}[0m\n      at tests/minimal.rs:41\n   1: \u{1b}[38;5;9mminimal\u{1b}[0m\u{1b}[38;5;9m::\u{1b}[0m\u{1b}[38;5;9mread_config\u{1b}[0m\n      at tests/minimal.rs:47\n\n\u{1b}[38;5;14mSuggestion\u{1b}[0m: try using a file that exists next time";
 


### PR DESCRIPTION
Fixes #21 