### PR TITLE
add testing for wasm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        target:
+          - x86_64-unknown-linux-gnu
+          - wasm32-unknown-unknown
         rust:
           - stable
           - beta
@@ -58,11 +61,21 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
         with:
+          target: ${{ matrix.target }}
           toolchain: ${{ matrix.rust }}
           override: true
+      - name: install test runner for wasm
+        run:  curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+        if: ${{ matrix.target == 'wasm32-unknown-unknown' }}
       - uses: actions-rs/cargo@v1
         with:
           command: test
+          target: ${{ matrix.target }}
+          toolchain: ${{ matrix.rust }}
+        if: ${{ matrix.target != 'wasm32-unknown-unknown' }}
+      - name: run wasm tests
+        run: wasm-pack test --node
+        if: ${{ matrix.target == 'wasm32-unknown-unknown' }}
 
   test-os:
     name: Test Suite

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,11 +25,13 @@ color-spantrace = { version = "0.1.4", optional = true }
 once_cell = "1.4.0"
 
 [dev-dependencies]
-wasm-bindgen-test = "0.3.15"
 tracing-subscriber = "0.2.5"
 tracing = "0.1.13"
 pretty_assertions = "0.6.1"
 thiserror = "1.0.19"
+
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+wasm-bindgen-test = "0.3.15"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ color-spantrace = { version = "0.1.4", optional = true }
 once_cell = "1.4.0"
 
 [dev-dependencies]
+wasm-bindgen-test = "0.3.15"
 tracing-subscriber = "0.2.5"
 tracing = "0.1.13"
 pretty_assertions = "0.6.1"

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,6 +18,7 @@ impl std::error::Error for InstallError {}
 
 /// A representation of a Frame from a Backtrace or a SpanTrace
 #[derive(Debug)]
+#[non_exhaustive]
 pub struct Frame {
     /// Frame index
     pub n: usize,
@@ -27,7 +28,6 @@ pub struct Frame {
     pub lineno: Option<u32>,
     /// source file path
     pub filename: Option<PathBuf>,
-    _private_ctor: (),
 }
 
 impl fmt::Display for Frame {
@@ -535,7 +535,6 @@ impl fmt::Display for BacktraceFormatter<'_> {
                 lineno: sym.lineno(),
                 filename: sym.filename().map(|x| x.into()),
                 n,
-                _private_ctor: (),
             })
             .collect();
 

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -1,10 +1,9 @@
-use color_eyre::eyre::WrapErr;
-use color_eyre::*;
-
-use wasm_bindgen_test::*;
-
-#[wasm_bindgen_test]
+#[cfg(target_arch = "wasm32")]
+#[wasm_bindgen_test::wasm_bindgen_test]
 pub fn color_eyre_simple() {
+    use color_eyre::eyre::WrapErr;
+    use color_eyre::*;
+
     install().expect("Failed to install color_eyre");
     let err_str = format!(
         "{:?}",

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -1,26 +1,24 @@
-use color_eyre::*;
 use color_eyre::eyre::WrapErr;
+use color_eyre::*;
 
 use wasm_bindgen_test::*;
 
 #[wasm_bindgen_test]
 pub fn color_eyre_simple() {
-  install().expect("Failed to install color_eyre");
-  let err_str = format!(
-      "{:?}",
-      Err::<(), Report>(
-          eyre::eyre!("Base Error")
-      )
-      .note("A note")
-      .suggestion("A suggestion")
-      .wrap_err("A wrapped error")
-      .unwrap_err()
-  );
-  // Print it out so if people run with `-- --nocapture`, they
-  // can see the full message.
-  println!("Error String is:\n\n{}", err_str);
-  assert!(err_str.contains("A wrapped error"));
-  assert!(err_str.contains("A suggestion"));
-  assert!(err_str.contains("A note"));
-  assert!(err_str.contains("Base Error"));
+    install().expect("Failed to install color_eyre");
+    let err_str = format!(
+        "{:?}",
+        Err::<(), Report>(eyre::eyre!("Base Error"))
+            .note("A note")
+            .suggestion("A suggestion")
+            .wrap_err("A wrapped error")
+            .unwrap_err()
+    );
+    // Print it out so if people run with `-- --nocapture`, they
+    // can see the full message.
+    println!("Error String is:\n\n{}", err_str);
+    assert!(err_str.contains("A wrapped error"));
+    assert!(err_str.contains("A suggestion"));
+    assert!(err_str.contains("A note"));
+    assert!(err_str.contains("Base Error"));
 }

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -1,0 +1,26 @@
+use color_eyre::*;
+use color_eyre::eyre::WrapErr;
+
+use wasm_bindgen_test::*;
+
+#[wasm_bindgen_test]
+pub fn color_eyre_simple() {
+  install().expect("Failed to install color_eyre");
+  let err_str = format!(
+      "{:?}",
+      Err::<(), Report>(
+          eyre::eyre!("Base Error")
+      )
+      .note("A note")
+      .suggestion("A suggestion")
+      .wrap_err("A wrapped error")
+      .unwrap_err()
+  );
+  // Print it out so if people run with `-- --nocapture`, they
+  // can see the full message.
+  println!("Error String is:\n\n{}", err_str);
+  assert!(err_str.contains("A wrapped error"));
+  assert!(err_str.contains("A suggestion"));
+  assert!(err_str.contains("A note"));
+  assert!(err_str.contains("Base Error"));
+}


### PR DESCRIPTION
fixes #37 

add testing in CI for `wasm` targets. Testing in WASM is a bit weird right now, since you need a wasm environment to actually run in. Also no wasm testing solutions support doctests (and even if they did most of the doctests in color-eyre depend on doing something like reading to STDOUT/STDIN, which most WASM ABIs don't have AFAIK).

As such the following has been done here:
  - Utilize a JS WASM environment tooling: `wasm-pack` && `wasm-bindgen-test`.
  - Create a test target they can "see" , adding a test folder, and using: `#[wasm_bindgen_test]`.
    - Have that test validate the bare minimum functionality: installing, printing out an error.
  - Run those tests using NodeJS so we don't have to worry about any browser weirdness.

Hopefully the approach is okay?  WASM made it a bit awkward, but I figured may as well start off the PR with what works. Ideally once tracing has added in wasm test support, we can also validate the tracing bit of functionality with another `#[wasm_bindgen_test]`, I figured we shouldn't add that before incase they accidentally break it somehow without meaning to because they aren't testing it.