### PR TITLE
print panics via eprinln to leverage test io capture

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -379,66 +379,76 @@ fn install_panic_hook() {
     std::panic::set_hook(Box::new(print_panic_info))
 }
 
-fn print_panic_info(pi: &std::panic::PanicInfo<'_>) {
-    let stderr = std::io::stderr();
-    let mut _out = stderr.lock();
-    eprintln!("{}", Red.paint("The application panicked (crashed)."));
+struct PanicPrinter<'a>(&'a std::panic::PanicInfo<'a>);
 
-    // Print panic message.
-    let payload = pi
-        .payload()
-        .downcast_ref::<String>()
-        .map(String::as_str)
-        .or_else(|| pi.payload().downcast_ref::<&str>().cloned())
-        .unwrap_or("<non string panic payload>");
+impl fmt::Display for PanicPrinter<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let pi = self.0;
 
-    eprint!("Message:  ");
-    eprintln!("{}", Cyan.paint(payload));
+        writeln!(f, "{}", Red.paint("The application panicked (crashed)."))?;
 
-    // If known, print panic location.
-    eprint!("Location: ");
-    if let Some(loc) = pi.location() {
-        eprint!("{}", Purple.paint(loc.file()));
-        eprint!(":");
-        eprintln!("{}", Purple.paint(loc.line().to_string()));
-    } else {
-        eprintln!("<unknown>");
-    }
+        // Print panic message.
+        let payload = pi
+            .payload()
+            .downcast_ref::<String>()
+            .map(String::as_str)
+            .or_else(|| pi.payload().downcast_ref::<&str>().cloned())
+            .unwrap_or("<non string panic payload>");
 
-    let v = panic_verbosity();
+        write!(f, "Message:  ")?;
+        writeln!(f, "{}", Cyan.paint(payload))?;
 
-    // Print some info on how to increase verbosity.
-    if v == Verbosity::Minimal {
-        eprint!("\nBacktrace omitted.\n\nRun with ");
-        eprint!("RUST_BACKTRACE=1");
-        eprintln!(" environment variable to display it.");
-    } else {
-        // This text only makes sense if frames are displayed.
-        eprint!("\nRun with ");
-        eprint!("COLORBT_SHOW_HIDDEN=1");
-        eprintln!(" environment variable to disable frame filtering.");
-    }
-    if v <= Verbosity::Medium {
-        eprint!("Run with ");
-        eprint!("RUST_BACKTRACE=full");
-        eprintln!(" to include source snippets.");
-    }
-
-    let printer = installed_printer();
-
-    #[cfg(feature = "capture-spantrace")]
-    {
-        if printer.spantrace_capture_enabled() {
-            let span_trace = tracing_error::SpanTrace::capture();
-            eprint!("{}", crate::writers::FormattedSpanTrace(&span_trace));
+        // If known, print panic location.
+        write!(f, "Location: ")?;
+        if let Some(loc) = pi.location() {
+            write!(f, "{}", Purple.paint(loc.file()))?;
+            write!(f, ":")?;
+            writeln!(f, "{}", Purple.paint(loc.line().to_string()))?;
+        } else {
+            writeln!(f, "<unknown>")?;
         }
-    }
 
-    if panic_verbosity() != Verbosity::Minimal {
-        let bt = backtrace::Backtrace::new();
-        let fmt_bt = printer.format_backtrace(&bt);
-        eprintln!("\n\n{}", fmt_bt);
+        let v = panic_verbosity();
+
+        // Print some info on how to increase verbosity.
+        if v == Verbosity::Minimal {
+            write!(f, "\nBacktrace omitted.\n\nRun with ")?;
+            write!(f, "RUST_BACKTRACE=1")?;
+            writeln!(f, " environment variable to display it.")?;
+        } else {
+            // This text only makes sense if frames are displayed.
+            write!(f, "\nRun with ")?;
+            write!(f, "COLORBT_SHOW_HIDDEN=1")?;
+            writeln!(f, " environment variable to disable frame filtering.")?;
+        }
+        if v <= Verbosity::Medium {
+            write!(f, "Run with ")?;
+            write!(f, "RUST_BACKTRACE=full")?;
+            writeln!(f, " to include source snippets.")?;
+        }
+
+        let printer = installed_printer();
+
+        #[cfg(feature = "capture-spantrace")]
+        {
+            if printer.spantrace_capture_enabled() {
+                let span_trace = tracing_error::SpanTrace::capture();
+                write!(f, "{}", crate::writers::FormattedSpanTrace(&span_trace))?;
+            }
+        }
+
+        if panic_verbosity() != Verbosity::Minimal {
+            let bt = backtrace::Backtrace::new();
+            let fmt_bt = printer.format_backtrace(&bt);
+            writeln!(f, "\n\n{}", fmt_bt)?;
+        }
+
+        Ok(())
     }
+}
+
+fn print_panic_info(pi: &std::panic::PanicInfo<'_>) {
+    eprintln!("{}", PanicPrinter(pi));
 }
 
 pub(crate) struct PanicHook {

--- a/src/config.rs
+++ b/src/config.rs
@@ -387,10 +387,10 @@ fn install_panic_hook() {
     std::panic::set_hook(Box::new(|pi| eprintln!("{}", PanicPrinter(pi))))
 }
 
-fn print_panic_info(printer: &PanicPrinter<'_>, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+fn print_panic_info(printer: &PanicPrinter<'_>, out: &mut fmt::Formatter<'_>) -> fmt::Result {
     let pi = printer.0;
 
-    writeln!(f, "{}", Red.paint("The application panicked (crashed)."))?;
+    writeln!(out, "{}", Red.paint("The application panicked (crashed)."))?;
 
     // Print panic message.
     let payload = pi
@@ -400,36 +400,36 @@ fn print_panic_info(printer: &PanicPrinter<'_>, f: &mut fmt::Formatter<'_>) -> f
         .or_else(|| pi.payload().downcast_ref::<&str>().cloned())
         .unwrap_or("<non string panic payload>");
 
-    write!(f, "Message:  ")?;
-    writeln!(f, "{}", Cyan.paint(payload))?;
+    write!(out, "Message:  ")?;
+    writeln!(out, "{}", Cyan.paint(payload))?;
 
     // If known, print panic location.
-    write!(f, "Location: ")?;
+    write!(out, "Location: ")?;
     if let Some(loc) = pi.location() {
-        write!(f, "{}", Purple.paint(loc.file()))?;
-        write!(f, ":")?;
-        writeln!(f, "{}", Purple.paint(loc.line().to_string()))?;
+        write!(out, "{}", Purple.paint(loc.file()))?;
+        write!(out, ":")?;
+        writeln!(out, "{}", Purple.paint(loc.line().to_string()))?;
     } else {
-        writeln!(f, "<unknown>")?;
+        writeln!(out, "<unknown>")?;
     }
 
     let v = panic_verbosity();
 
     // Print some info on how to increase verbosity.
     if v == Verbosity::Minimal {
-        write!(f, "\nBacktrace omitted.\n\nRun with ")?;
-        write!(f, "RUST_BACKTRACE=1")?;
-        writeln!(f, " environment variable to display it.")?;
+        write!(out, "\nBacktrace omitted.\n\nRun with ")?;
+        write!(out, "RUST_BACKTRACE=1")?;
+        writeln!(out, " environment variable to display it.")?;
     } else {
         // This text only makes sense if frames are displayed.
-        write!(f, "\nRun with ")?;
-        write!(f, "COLORBT_SHOW_HIDDEN=1")?;
-        writeln!(f, " environment variable to disable frame filtering.")?;
+        write!(out, "\nRun with ")?;
+        write!(out, "COLORBT_SHOW_HIDDEN=1")?;
+        writeln!(out, " environment variable to disable frame filtering.")?;
     }
     if v <= Verbosity::Medium {
-        write!(f, "Run with ")?;
-        write!(f, "RUST_BACKTRACE=full")?;
-        writeln!(f, " to include source snippets.")?;
+        write!(out, "Run with ")?;
+        write!(out, "RUST_BACKTRACE=full")?;
+        writeln!(out, " to include source snippets.")?;
     }
 
     let printer = installed_printer();
@@ -438,14 +438,14 @@ fn print_panic_info(printer: &PanicPrinter<'_>, f: &mut fmt::Formatter<'_>) -> f
     {
         if printer.spantrace_capture_enabled() {
             let span_trace = tracing_error::SpanTrace::capture();
-            write!(f, "{}", crate::writers::FormattedSpanTrace(&span_trace))?;
+            write!(out, "{}", crate::writers::FormattedSpanTrace(&span_trace))?;
         }
     }
 
     if panic_verbosity() != Verbosity::Minimal {
         let bt = backtrace::Backtrace::new();
         let fmt_bt = printer.format_backtrace(&bt);
-        writeln!(f, "\n\n{}", fmt_bt)?;
+        writeln!(out, "\n\n{}", fmt_bt)?;
     }
 
     Ok(())


### PR DESCRIPTION
As it is currently written `color-eyre`'s panic handler prevents the output from the panic handler from being captured during tests. This is because the code this panic handler is based on, `color-backtrace`, was based on the implementation of the panic handler in libstd, except `color-backtrace` accidentally changed the behavior when they reimplemented it based on `std::io::stderr()` and `termcolor`

In libstd the panic handler works by grabbing a handle to stderr and then invoking the panic handler function with this handle, always calling `write!` and such macros to write to the handle and handling the errors. This logic is necessary to prevent output from becoming interleaved with print calls from other threads. However, the function that `libstd` uses to grab the handle to `stderr` is _not_ `std::io::stderr()`. It is infact a particularly unstable internal API called `set_panic`. This function returns the handle to `LOCAL_STDERR`, a super special version of `stderr` that is stored in a thread local variable that is modified by rust's builtin test framework prior to calling each test. `std::io::stderr()` on the other hand always returns a handle to the real active and current stderr of the process, which will be the same stderr handle being used by rust's test framework, thus showing the output even when the test passes.

To prevent this we need to use print APIs that _are_ actually captured and go to `LOCAL_STDOUT` and `LOCAL_STDERR`. Rust exposes these via the `eprintln` and `println` macros. The problem with using these macros in the panic handler itself is that these macros acquire the lock on their respective handles only for the duration of the call. Using these macros instead of printing to the lock would allow other threads to interleave their output with our panic message. To avoid re-introducing this original issue we need to move our implementation of our panic handling function into a `Display` trait impl to print our entire report in one `eprintln!` call.

The original upstream library we based our panic handler on did not do this because it is based on `termcolor` instead of `ansi_term`. `termcolor` is a more backwards compatible library than `ansi_term`, and has an API that supports modifying colors for terminals in older versions of windows than `ansi_term`. However this more backwards compatible API works, at least partially, by being based on the `std::io::Write` trait, rather than `std::fmt::Display`, which `ansi_term` is compatible with.

`color-eyre` was already forced to switch to `ansi_term` in the past to support printing error reports via the `Display` and `Debug` traits. As such we no longer need to rely on manually capturing `std::io::stderr()` and calling `write!` with various `termcolor` helpers. Instead we can call `eprintln!("{}", PanicPrinter(panic_info));` and acquire the lock to the LOCAL_STDERR for the duration of our panic printing function and access it via `std::fmt::Formatter<'_>`.

fixes https://github.com/ZcashFoundation/zebra/issues/759