### PR TITLE
Add panic_note to HookBuilder

### DIFF
--- a/examples/panic_hook.rs
+++ b/examples/panic_hook.rs
@@ -7,7 +7,7 @@ fn main() -> Result<(), Report> {
     install_tracing();
 
     color_eyre::config::HookBuilder::default()
-        .panic_note("consider reporting the bug at github")
+        .panic_note("consider reporting the bug on github")
         .install()?;
 
     read_config();

--- a/examples/panic_hook.rs
+++ b/examples/panic_hook.rs
@@ -6,7 +6,9 @@ fn main() -> Result<(), Report> {
     #[cfg(feature = "capture-spantrace")]
     install_tracing();
 
-    color_eyre::install()?;
+    color_eyre::config::HookBuilder::default()
+        .panic_note("consider reporting the bug at github")
+        .install()?;
 
     read_config();
 

--- a/examples/panic_hook.rs
+++ b/examples/panic_hook.rs
@@ -7,7 +7,7 @@ fn main() -> Result<(), Report> {
     install_tracing();
 
     color_eyre::config::HookBuilder::default()
-        .panic_note("consider reporting the bug on github")
+        .panic_section("consider reporting the bug on github")
         .install()?;
 
     read_config();

--- a/src/config.rs
+++ b/src/config.rs
@@ -285,7 +285,7 @@ impl HookBuilder {
         }
     }
 
-    /// Add a custom note to the panic hook that will be printed
+    /// Add a custom section to the panic hook that will be printed
     /// in the panic message.
     ///
     /// # Examples
@@ -484,6 +484,10 @@ fn print_panic_info(printer: &PanicPrinter<'_>, out: &mut fmt::Formatter<'_>) ->
 
     let mut separated = out.header("\n\n");
 
+    if let Some(ref section) = printer.section {
+        write!(&mut separated.ready(), "{}", section)?;
+    }
+
     #[cfg(feature = "capture-spantrace")]
     {
         if let Some(span_trace) = span_trace.as_ref() {
@@ -515,10 +519,6 @@ fn print_panic_info(printer: &PanicPrinter<'_>, out: &mut fmt::Formatter<'_>) ->
         };
 
         write!(&mut separated.ready(), "{}", env_section)?;
-    }
-
-    if let Some(ref section) = printer.section {
-        write!(&mut separated.ready(), "{}", section)?;
     }
 
     Ok(())


### PR DESCRIPTION
This PR implements a new property, `panic_note`, in the `HookBuilder`, that will be printed in the panic message

Resolves #50 