### PR TITLE
Replace Help trait with Section trait in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ error originated from, assuming it can find them on the disk.
 
 ![full report format](https://raw.githubusercontent.com/yaahc/color-eyre/master/pictures/full.png)
 
-### Custom `Section`s for error reports via [`Help`] trait
+### Custom `Section`s for error reports via [`Section`] trait
 
 The `section` module provides helpers for adding extra sections to error
 reports. Sections are disinct from error messages and are displayed
@@ -130,7 +130,7 @@ to contain `stderr` and `stdout` from a failed command, taken from
 [`examples/custom_section.rs`]:
 
 ```rust
-use color_eyre::{eyre::eyre, SectionExt, Help, eyre::Report};
+use color_eyre::{eyre::eyre, SectionExt, Section, eyre::Report};
 use std::process::Command;
 use tracing::instrument;
 
@@ -182,7 +182,7 @@ done](https://github.com/rust-lang/rfcs/pull/2895) to improve this.
 
 For now however one way to work around this is to compose errors outside the
 error trait. `color-eyre` supports such composition in its error reports via
-the `Help` trait.
+the `Section` trait.
 
 For an example of how to aggregate errors check out [`examples/multiple_errors.rs`].
 
@@ -206,7 +206,7 @@ For an example of how to setup custom filters, check out [`examples/custom_filte
 [`backtrace::Backtrace`]: https://docs.rs/backtrace/*/backtrace/struct.Backtrace.html
 [`tracing_error::SpanTrace`]: https://docs.rs/tracing-error/*/tracing_error/struct.SpanTrace.html
 [`color-spantrace`]: https://github.com/yaahc/color-spantrace
-[`Help`]: https://docs.rs/color-eyre/*/color_eyre/trait.Help.html
+[`Section`]: https://docs.rs/color-eyre/*/color_eyre/trait.Section.html
 [`eyre::Report`]: https://docs.rs/eyre/*/eyre/struct.Report.html
 [`eyre::Result`]: https://docs.rs/eyre/*/eyre/type.Result.html
 [`Handler`]: https://docs.rs/color-eyre/*/color_eyre/struct.Handler.html


### PR DESCRIPTION
In the README the `Help` trait was still used instead of the `Section` trait.