### PR TITLE
Fix a typo: indenteted ~> indented

### DIFF
--- a/src/section/mod.rs
+++ b/src/section/mod.rs
@@ -4,7 +4,7 @@ use std::fmt::{self, Display};
 
 pub(crate) mod help;
 
-/// An indenteted section with a header for an error report
+/// An indented section with a header for an error report
 ///
 /// # Details
 ///


### PR DESCRIPTION
I was skimming the changes in https://github.com/yaahc/color-eyre/pull/62, and spotted what looks like a typo at the bottom of the diff.