### PR TITLE
Add feature more gates for capture-spantrace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,18 @@ jobs:
         with:
           command: test
           args: --no-default-features
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features --features issue-url
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features --features track-caller
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features --features capture-spantrace
 
   test-versions:
     name: Test Suite

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           command: check
 
   test-features:
-    name: Test Suite
+    name: Test Features
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
@@ -58,7 +58,7 @@ jobs:
           args: --no-default-features --features capture-spantrace
 
   test-versions:
-    name: Test Suite
+    name: Test Versions
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -90,7 +90,7 @@ jobs:
         if: ${{ matrix.target == 'wasm32-unknown-unknown' }}
 
   test-os:
-    name: Test Suite
+    name: Test Operating Systems
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/src/section/github.rs
+++ b/src/section/github.rs
@@ -1,6 +1,7 @@
 use crate::writers::DisplayExt;
 use backtrace::Backtrace;
 use std::{fmt, panic::Location};
+#[cfg(feature = "capture-spantrace")]
 use tracing_error::SpanTrace;
 use url::Url;
 
@@ -11,6 +12,7 @@ pub(crate) struct IssueSection<'a> {
     msg: &'a str,
     location: Option<&'a Location<'a>>,
     backtrace: Option<&'a Backtrace>,
+    #[cfg(feature = "capture-spantrace")]
     span_trace: Option<&'a SpanTrace>,
     metadata: &'a [(String, Display<'a>)],
 }
@@ -22,6 +24,7 @@ impl<'a> IssueSection<'a> {
             msg,
             location: None,
             backtrace: None,
+            #[cfg(feature = "capture-spantrace")]
             span_trace: None,
             metadata: &[],
         }
@@ -37,6 +40,7 @@ impl<'a> IssueSection<'a> {
         self
     }
 
+    #[cfg(feature = "capture-spantrace")]
     pub(crate) fn with_span_trace(mut self, span_trace: impl Into<Option<&'a SpanTrace>>) -> Self {
         self.span_trace = span_trace.into();
         self
@@ -62,6 +66,7 @@ impl fmt::Display for IssueSection<'_> {
             body.push_section("Metadata", metadata)?;
         }
 
+        #[cfg(feature = "capture-spantrace")]
         if let Some(st) = self.span_trace {
             body.push_section(
                 "SpanTrace",

--- a/src/section/mod.rs
+++ b/src/section/mod.rs
@@ -86,7 +86,7 @@ pub trait SectionExt: Sized {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```rust,no_run
     /// use color_eyre::{eyre::eyre, Help, SectionExt, eyre::Report};
     ///
     /// let all_in_header = "header\n   body\n   body";


### PR DESCRIPTION
When only the `issue-url` features is enabled, with the default
features being disabled, the crate fails to build

```
$ cargo build --no-default-features --features issue-url
   Compiling color-eyre v0.5.7-alpha.0 (/Users/paul/dev/color-eyre)
error[E0432]: unresolved import `tracing_error`
 --> src/section/github.rs:5:5
  |
5 | use tracing_error::SpanTrace;
  |     ^^^^^^^^^^^^^ use of undeclared type or module `tracing_error`

error[E0282]: type annotations needed
  --> src/section/github.rs:28:25
   |
28 |             span_trace: None,
   |                         ^^^^ cannot infer type for type parameter `T` declared on the enum `Option`

error: aborting due to 2 previous errors
```

This commit add feature gates for capture-spantrace to the github
issue module, so that the issue-url feature can be used standalone.
