### PR TITLE
upgwade owo-cowows to 2.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ eyre = "0.6.1"
 tracing-error = { version = "0.1.2", optional = true }
 backtrace = { version = "0.3.48", features = ["gimli-symbolize"] }
 indenter = "0.3.0"
-owo-colors = "1.2.1"
+owo-colors = "2.0.0"
 color-spantrace = { version = "0.1.6", optional = true }
 once_cell = "1.4.0"
 url = { version = "2.1.1", optional = true }


### PR DESCRIPTION
me confiwmed that dis wowks with [yaahc/cowow-spantwace#13](https://github.com/yaahc/cowow-spantwace/puww/13).

<details><summary>translation</summary>

upgrade owo-colors to 2.0.0

I confirmed that this works with  yaahc/color-spantrace#13.

(I'm both sorry and not.)
</details>