### PR TITLE
Fix (some) warnings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -338,7 +338,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(
     missing_docs,
-    missing_doc_code_examples,
+    rustdoc::missing_doc_code_examples,
     rust_2018_idioms,
     unreachable_pub,
     bad_style,

--- a/tests/theme.rs
+++ b/tests/theme.rs
@@ -160,7 +160,7 @@ fn test_backwards_compatibility(target: String, file_name: &str) {
             })
             .collect();
         (all, ansi)
-    };
+    }
 
     let (_control_tokens, control_ansi) = f(&control);
     let (_target_tokens, target_ansi) = f(&target);


### PR DESCRIPTION
I couldn't fix the warning around `panic!(error)` because changing to `panic!("{}", error)` or `std::panic::panic_any(error)` failed the test