### PR TITLE
Join backtrace omission lines

### DIFF
--- a/src/writers.rs
+++ b/src/writers.rs
@@ -229,7 +229,10 @@ impl fmt::Display for BacktraceOmited {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // Print some info on how to increase verbosity.
         if self.0 {
-            write!(f, "Backtrace omitted. Run with RUST_BACKTRACE=1 environment variable to display it.")?;
+            write!(
+                f,
+                "Backtrace omitted. Run with RUST_BACKTRACE=1 environment variable to display it."
+            )?;
         } else {
             // This text only makes sense if frames are displayed.
             write!(

--- a/src/writers.rs
+++ b/src/writers.rs
@@ -229,11 +229,7 @@ impl fmt::Display for BacktraceOmited {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // Print some info on how to increase verbosity.
         if self.0 {
-            writeln!(f, "Backtrace omitted.")?;
-            write!(
-                f,
-                "Run with RUST_BACKTRACE=1 environment variable to display it."
-            )?;
+            write!(f, "Backtrace omitted. Run with RUST_BACKTRACE=1 environment variable to display it.")?;
         } else {
             // This text only makes sense if frames are displayed.
             write!(


### PR DESCRIPTION
Merge the two backtrace omission lines:

```bash
ana@autonoma:~/git/eyre-demo$ cargo run
    Finished dev [unoptimized + debuginfo] target(s) in 0.01s
     Running `target/debug/eyre-demo`
Error: 
   0: Whoops

Location:
   /home/ana/.cargo/registry/src/github.com-1ecc6299db9ec823/eyre-0.6.6/src/lib.rs:1164

Backtrace omitted.
Run with RUST_BACKTRACE=1 environment variable to display it.
Run with RUST_BACKTRACE=full to include source snippets.
```

Resulting in:

```bash
ana@autonoma:~/git/eyre-demo$ cargo run
    Finished dev [unoptimized + debuginfo] target(s) in 0.01s
     Running `target/debug/eyre-demo`
Error: 
   0: Whoops

Location:
   src/main.rs:4

Backtrace omitted. Run with RUST_BACKTRACE=1 environment variable to display it.
Run with RUST_BACKTRACE=full to include source snippets.
```


They amount to exactly 80 characters (as @mgattozzi noted would be good)

![image](https://user-images.githubusercontent.com/130903/155634702-c86af45e-833c-4b3e-9557-33909fdb206d.png)

