### PR TITLE
add config option to disable location section

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -418,6 +418,8 @@ pub struct HookBuilder {
     filters: Vec<Box<FilterCallback>>,
     capture_span_trace_by_default: bool,
     display_env_section: bool,
+    #[cfg(feature = "track-caller")]
+    display_location_section: bool,
     panic_section: Option<Box<dyn Display + Send + Sync + 'static>>,
     panic_message: Option<Box<dyn PanicMessage>>,
     theme: Theme,
@@ -459,6 +461,8 @@ impl HookBuilder {
             filters: vec![],
             capture_span_trace_by_default: false,
             display_env_section: true,
+            #[cfg(feature = "track-caller")]
+            display_location_section: true,
             panic_section: None,
             panic_message: None,
             theme: Theme::dark(),
@@ -649,6 +653,18 @@ impl HookBuilder {
         self
     }
 
+    /// Configures the location info section and whether or not it is displayed.
+    ///
+    /// # Notes
+    ///
+    /// This will not disable the location section in a panic message.
+    #[cfg(feature = "track-caller")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "track-caller")))]
+    pub fn display_location_section(mut self, cond: bool) -> Self {
+        self.display_location_section = cond;
+        self
+    }
+
     /// Add a custom filter to the set of frame filters
     ///
     /// # Examples
@@ -723,6 +739,8 @@ impl HookBuilder {
             #[cfg(feature = "capture-spantrace")]
             capture_span_trace_by_default: self.capture_span_trace_by_default,
             display_env_section: self.display_env_section,
+            #[cfg(feature = "track-caller")]
+            display_location_section: self.display_location_section,
             theme,
             #[cfg(feature = "issue-url")]
             issue_url: self.issue_url,
@@ -1000,6 +1018,8 @@ pub struct EyreHook {
     #[cfg(feature = "capture-spantrace")]
     capture_span_trace_by_default: bool,
     display_env_section: bool,
+    #[cfg(feature = "track-caller")]
+    display_location_section: bool,
     theme: Theme,
     #[cfg(feature = "issue-url")]
     issue_url: Option<String>,
@@ -1034,6 +1054,8 @@ impl EyreHook {
             span_trace,
             sections: Vec::new(),
             display_env_section: self.display_env_section,
+            #[cfg(feature = "track-caller")]
+            display_location_section: self.display_location_section,
             #[cfg(feature = "issue-url")]
             issue_url: self.issue_url.clone(),
             #[cfg(feature = "issue-url")]

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -69,14 +69,16 @@ impl eyre::EyreHandler for Handler {
         let mut separated = f.header("\n\n");
 
         #[cfg(feature = "track-caller")]
-        write!(
-            separated.ready(),
-            "{}",
-            crate::SectionExt::header(
-                crate::fmt::LocationSection(self.location, self.theme),
-                "Location:"
-            )
-        )?;
+        if self.display_location_section {
+            write!(
+                separated.ready(),
+                "{}",
+                crate::SectionExt::header(
+                    crate::fmt::LocationSection(self.location, self.theme),
+                    "Location:"
+                )
+            )?;
+        }
 
         for section in self
             .sections

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -404,6 +404,8 @@ pub struct Handler {
     span_trace: Option<SpanTrace>,
     sections: Vec<HelpInfo>,
     display_env_section: bool,
+    #[cfg(feature = "track-caller")]
+    display_location_section: bool,
     #[cfg(feature = "issue-url")]
     issue_url: Option<String>,
     #[cfg(feature = "issue-url")]

--- a/tests/location_disabled.rs
+++ b/tests/location_disabled.rs
@@ -1,0 +1,16 @@
+#[cfg(feature = "track-caller")]
+#[test]
+fn disabled() {
+    use color_eyre::eyre;
+    use eyre::eyre;
+
+    color_eyre::config::HookBuilder::default()
+        .display_location_section(false)
+        .install()
+        .unwrap();
+
+    let report = eyre!("error occured");
+
+    let report = format!("{:?}", report);
+    assert!(!report.contains("Location:"));
+}


### PR DESCRIPTION
resolves #105

I'm not sure how to handle the panic hook.
I think it makes sense to always display the location even if we've set the config to false.

If this is unexpected (I think it isn't), it should be possible to implement by adding a field to `DefaultPanicMessage`