### PR TITLE
Add context_from traits from zebra-test to upstream color-eyre crate

### DIFF
--- a/examples/context_from_commands.rs
+++ b/examples/context_from_commands.rs
@@ -1,0 +1,49 @@
+use color_eyre::{eyre, section::ContextFrom};
+use tracing::instrument;
+
+#[instrument]
+fn main() -> eyre::Result<()> {
+    #[cfg(feature = "capture-spantrace")]
+    install_tracing();
+
+    color_eyre::install()?;
+
+    visit_the_shell()?;
+
+    Ok(())
+}
+
+#[cfg(feature = "capture-spantrace")]
+fn install_tracing() {
+    use tracing_error::ErrorLayer;
+    use tracing_subscriber::prelude::*;
+    use tracing_subscriber::{fmt, EnvFilter};
+
+    let fmt_layer = fmt::layer().with_target(false);
+    let filter_layer = EnvFilter::try_from_default_env()
+        .or_else(|_| EnvFilter::try_new("info"))
+        .unwrap();
+
+    tracing_subscriber::registry()
+        .with(filter_layer)
+        .with(fmt_layer)
+        .with(ErrorLayer::default())
+        .init();
+}
+
+#[instrument]
+fn visit_the_shell() -> eyre::Result<()> {
+    let mut cmd = std::process::Command::new("bash");
+    cmd.arg("-c")
+        // uh oh, there's an extra ' in that string and bash isn't gonna like it!
+        .arg("echo 'Hello bash, I hope you're doing well!'");
+    let output = cmd.output().context_from(&cmd)?;
+    if !output.status.success() {
+        Err(eyre::eyre!("invalid bash command"))
+            .context_from(&cmd)
+            .context_from(&output)
+    } else {
+        // I know the command is invalid ;)
+        Ok(())
+    }
+}

--- a/src/section/context_from.rs
+++ b/src/section/context_from.rs
@@ -1,0 +1,79 @@
+use crate::{Help, Report, SectionExt};
+#[cfg(unix)]
+use std::os::unix::prelude::ExitStatusExt;
+
+/// Add context to an error report
+pub trait ContextFrom<S> {
+    /// The return type of the context_from combinator
+    type Return;
+
+    /// Insert context from `source` into `self`
+    ///
+    /// Used to abstract over gathering relevant context from specific types into error reports.
+    fn context_from(self, source: S) -> Self::Return;
+}
+
+impl<C, T, E> ContextFrom<C> for Result<T, E>
+where
+    E: Into<Report>,
+    Report: ContextFrom<C, Return = Report>,
+{
+    type Return = Result<T, Report>;
+
+    fn context_from(self, source: C) -> Self::Return {
+        self.map_err(|e| e.into())
+            .map_err(|report| report.context_from(source))
+    }
+}
+
+impl ContextFrom<&std::process::Command> for Report {
+    type Return = Report;
+
+    fn context_from(self, source: &std::process::Command) -> Self::Return {
+        let original_cmd = format!("{:?}", source);
+        self.section(original_cmd.header("Command:"))
+    }
+}
+
+impl ContextFrom<&std::process::Output> for Report {
+    type Return = Report;
+
+    fn context_from(self, source: &std::process::Output) -> Self::Return {
+        let stdout = String::from_utf8_lossy(&source.stdout).into_owned();
+        let stderr = String::from_utf8_lossy(&source.stderr).into_owned();
+        self.context_from(&source.status)
+            .section(stdout.header("Stdout:"))
+            .section(stderr.header("Stderr:"))
+    }
+}
+
+impl ContextFrom<&std::process::ExitStatus> for Report {
+    type Return = Report;
+
+    fn context_from(self, source: &std::process::ExitStatus) -> Self::Return {
+        let how = if source.success() {
+            "successfully"
+        } else {
+            "unsuccessfully"
+        };
+
+        if let Some(code) = source.code() {
+            let msg = format!("command exited {} with status code {}", how, code);
+            return self.section(msg.header("Exit Status:"));
+        }
+
+        #[cfg(unix)]
+        if let Some(signal) = source.signal() {
+            let msg = format!("command terminated {} by signal {}", how, signal);
+            self.section(msg.header("Exit Status:"))
+        } else {
+            unreachable!("on unix all processes either terminate via signal or with an exit code");
+        }
+
+        #[cfg(not(unix))]
+        {
+            let msg = format!("command exited {} without a status code or signal", how);
+            self.section(msg.header("Exit Status:"))
+        }
+    }
+}

--- a/src/section/mod.rs
+++ b/src/section/mod.rs
@@ -2,9 +2,12 @@
 use crate::writers::WriterExt;
 use std::fmt::{self, Display};
 
+pub(crate) mod context_from;
 #[cfg(feature = "issue-url")]
 pub(crate) mod github;
 pub(crate) mod help;
+
+pub use context_from::ContextFrom;
 
 /// An indented section with a header for an error report
 ///


### PR DESCRIPTION
I originally wrote this trait as part of the `zebra-test`[^1] crate to abstract over the act of adding context from an external command to an error report in our various helper methods. I particularly like this pattern am curious to see if it applies cleanly to many other types during error reporting and want to add it to `color-eyre` proper so users of this crate can potentially implement it on their types.

TODO
=====

- [ ] add tests
- [ ] Add more detailed documentation to the ContextFrom trait, including an example of implementing it for a user's type
- [ ] Add an example to the lib.rs docs and readme showing the usage with `std::process::Command`.

Output
=====

The following example:

```rust
fn visit_the_shell() -> eyre::Result<()> {
    let mut cmd = std::process::Command::new("bash");
    cmd.arg("-c")
        // uh oh, there's an extra ' in that string and bash isn't gonna like it!
        .arg("echo 'Hello bash, I hope you're doing well!'");
    let output = cmd.output().context_from(&cmd)?;
    if !output.status.success() {
        Err(eyre::eyre!("invalid bash command"))
            .context_from(&cmd)
            .context_from(&output)
    } else {
        // I know the command is invalid ;)
        Ok(())
    }
}
```

Produces the following output:

![Screenshot from 2022-04-08 22-41-43](https://user-images.githubusercontent.com/1993852/162558229-f0718fd9-55b1-4ff8-a0f5-40f153496f1c.png)

[^1]: https://github.com/ZcashFoundation/zebra/blob/main/zebra-test/src/command.rs#L1138