### PR TITLE
add `suppress_backtrace` method

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1030,6 +1030,7 @@ impl EyreHook {
         crate::Handler {
             filters: self.filters.clone(),
             backtrace,
+            suppress_backtrace: false,
             #[cfg(feature = "capture-spantrace")]
             span_trace,
             sections: Vec::new(),

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -111,14 +111,16 @@ impl eyre::EyreHandler for Handler {
             }
         }
 
-        if let Some(backtrace) = self.backtrace.as_ref() {
-            let fmted_bt = self.format_backtrace(backtrace);
+        if !self.suppress_backtrace {
+            if let Some(backtrace) = self.backtrace.as_ref() {
+                let fmted_bt = self.format_backtrace(backtrace);
 
-            write!(
-                indented(&mut separated.ready()).with_format(Format::Uniform { indentation: "  " }),
-                "{}",
-                fmted_bt
-            )?;
+                write!(
+                    indented(&mut separated.ready()).with_format(Format::Uniform { indentation: "  " }),
+                    "{}",
+                    fmted_bt
+                )?;
+            }
         }
 
         let f = separated.ready();

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -118,7 +118,8 @@ impl eyre::EyreHandler for Handler {
                 let fmted_bt = self.format_backtrace(backtrace);
 
                 write!(
-                    indented(&mut separated.ready()).with_format(Format::Uniform { indentation: "  " }),
+                    indented(&mut separated.ready())
+                        .with_format(Format::Uniform { indentation: "  " }),
                     "{}",
                     fmted_bt
                 )?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -400,6 +400,7 @@ mod writers;
 pub struct Handler {
     filters: Arc<[Box<config::FilterCallback>]>,
     backtrace: Option<Backtrace>,
+    suppress_backtrace: bool,
     #[cfg(feature = "capture-spantrace")]
     span_trace: Option<SpanTrace>,
     sections: Vec<HelpInfo>,

--- a/src/section/help.rs
+++ b/src/section/help.rs
@@ -142,6 +142,14 @@ impl Section for Report {
 
         self
     }
+
+    fn suppress_backtrace(mut self, suppress: bool) -> Self::Return {
+        if let Some(handler) = self.handler_mut().downcast_mut::<crate::Handler>() {
+            handler.suppress_backtrace = suppress;
+        }
+
+        self
+    }
 }
 
 impl<T, E> Section for Result<T, E>
@@ -233,6 +241,11 @@ where
     {
         self.map_err(|error| error.into())
             .map_err(|report| report.error(error()))
+    }
+
+    fn suppress_backtrace(self, suppress: bool) -> Self::Return {
+        self.map_err(|error| error.into())
+            .map_err(|report| report.suppress_backtrace(suppress))
     }
 }
 

--- a/src/section/mod.rs
+++ b/src/section/mod.rs
@@ -315,6 +315,12 @@ pub trait Section: crate::private::Sealed {
     where
         D: Display + Send + Sync + 'static,
         F: FnOnce() -> D;
+
+    /// Whether to suppress printing of collected backtrace (if any).
+    ///
+    /// Useful for reporting "unexceptional" errors for which a backtrace
+    /// isn't really necessary.
+    fn suppress_backtrace(self, suppress: bool) -> Self::Return;
 }
 
 /// Trait for printing a panic error message for the given PanicInfo


### PR DESCRIPTION
In my application, there are certain errors that are mundane enough that I don't really need a backtrace. But I still want to be able to propagate the error using all the nice eyre machinery I've set up. This PR adds a `suppress_backtrace` method which lets you do just that.

To expand a bit: in my application's `main` I set `RUST_BACKTRACE` to `1`:

```rust
// Automatically enable backtracing unless user explicitly disabled it
if env::var("RUST_BACKTRACE").is_err() {
    env::set_var("RUST_BACKTRACE", "1");
}
```

This is so that when people report problems with my application, it will always spit out a useful backtrace that they can provide.