### PR TITLE
fix: Do not panic on multiple `install` calls

### DIFF
--- a/examples/panic_compose.rs
+++ b/examples/panic_compose.rs
@@ -6,9 +6,7 @@ fn main() -> Result<(), Report> {
     #[cfg(feature = "capture-spantrace")]
     install_tracing();
 
-    let (panic_hook, eyre_hook) = color_eyre::config::HookBuilder::default()
-        .into_hooks()
-        .expect("failed to setup hooks");
+    let (panic_hook, eyre_hook) = color_eyre::config::HookBuilder::default().into_hooks();
 
     eyre_hook.install()?;
 

--- a/examples/panic_compose.rs
+++ b/examples/panic_compose.rs
@@ -6,7 +6,9 @@ fn main() -> Result<(), Report> {
     #[cfg(feature = "capture-spantrace")]
     install_tracing();
 
-    let (panic_hook, eyre_hook) = color_eyre::config::HookBuilder::default().into_hooks();
+    let (panic_hook, eyre_hook) = color_eyre::config::HookBuilder::default()
+        .into_hooks()
+        .expect("failed to setup hooks");
 
     eyre_hook.install()?;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -716,7 +716,7 @@ impl HookBuilder {
     /// Create a `PanicHook` and `EyreHook` from this `HookBuilder`.
     /// This can be used if you want to combine these handlers with other handlers.
     pub fn into_hooks(self) -> (PanicHook, EyreHook) {
-        self.try_into_hooks().expect("failed to turn into hooks")
+        self.try_into_hooks().expect("into_hooks should only be called when no `color_spantrace` themes have previously been set")
     }
 
     /// Create a `PanicHook` and `EyreHook` from this `HookBuilder`.

--- a/src/config.rs
+++ b/src/config.rs
@@ -701,7 +701,7 @@ impl HookBuilder {
 
     /// Install the given Hook as the global error report hook
     pub fn install(self) -> Result<(), crate::eyre::Report> {
-        let (panic_hook, eyre_hook) = self.into_hooks()?;
+        let (panic_hook, eyre_hook) = self.try_into_hooks()?;
         eyre_hook.install()?;
         panic_hook.install();
         Ok(())
@@ -715,7 +715,13 @@ impl HookBuilder {
 
     /// Create a `PanicHook` and `EyreHook` from this `HookBuilder`.
     /// This can be used if you want to combine these handlers with other handlers.
-    pub fn into_hooks(self) -> Result<(PanicHook, EyreHook), crate::eyre::Report> {
+    pub fn into_hooks(self) -> (PanicHook, EyreHook) {
+        self.try_into_hooks().expect("failed to turn into hooks")
+    }
+
+    /// Create a `PanicHook` and `EyreHook` from this `HookBuilder`.
+    /// This can be used if you want to combine these handlers with other handlers.
+    pub fn try_into_hooks(self) -> Result<(PanicHook, EyreHook), crate::eyre::Report> {
         let theme = self.theme;
         #[cfg(feature = "issue-url")]
         let metadata = Arc::new(self.issue_metadata);

--- a/tests/install.rs
+++ b/tests/install.rs
@@ -1,0 +1,7 @@
+use color_eyre::install;
+
+#[test]
+fn double_install_should_not_panic() {
+    install().unwrap();
+    assert!(install().is_err());
+}


### PR DESCRIPTION
When writing tests it is really useful to use color-eyre to have better messages but, calling install multiple times will panic.
This should return an error instead.
It should fix #97
