### PR TITLE
Example of how to call `color_eyre::install()` multiple times safely.

### DIFF
--- a/examples/cargo_tests.rs
+++ b/examples/cargo_tests.rs
@@ -1,0 +1,70 @@
+//!
+//! Try it out with cargo test --example cargo_tests -- --nocapture
+
+use color_eyre::{eyre::Result};
+use eyre::bail;
+use tracing::{info, instrument};
+
+#[instrument]
+fn do_some_work_well() -> Result<()> {
+    info!("Doing some work.");
+    Ok(())
+}
+
+#[instrument]
+fn do_some_work_badly() -> Result<()> {
+    bail!("Something went wrong")
+}
+
+fn main() -> Result<()> {
+    do_some_work_well()?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // cargo test --example cargo_tests -- --nocapture
+    // put mod somewhere accessible so that it can be used elsewhere.
+    pub mod some_common_spot {
+        use once_cell::sync::OnceCell;
+
+        pub struct ColorEyreGuard(());
+        static INIT_COLOR_EYRE: OnceCell<ColorEyreGuard> = OnceCell::new();
+
+        pub fn init_color_eyre() {
+            INIT_COLOR_EYRE.get_or_init(|| {
+                if std::env::var("RUST_SPANTRACE").is_err() {
+                    std::env::set_var("RUST_SPANTRACE", "0");
+                }
+                // Run with RUST_BACKTRACE=1 to see the backtrace. 
+                if std::env::var("RUST_BACKTRACE").is_err() {
+                    std::env::set_var("RUST_BACKTRACE", "0");
+                }
+                if std::env::var("COLOR_EYRE").is_err() {
+                    std::env::set_var("COLOR_EYRE", "1");
+                }
+                if std::env::var("COLOR_EYRE").unwrap() == "1" {
+                    color_eyre::install().expect("Failed to initialize color_eyre");
+                }
+                ColorEyreGuard(())
+            });
+        }
+    }
+
+    #[test]
+    fn test_eyre_init() {
+        some_common_spot::init_color_eyre();
+        do_some_work_badly().unwrap();
+        assert!(true);
+    }
+
+    #[test]
+    fn test_without_colors_work_as_is() {
+        some_common_spot::init_color_eyre();
+        do_some_work_badly().unwrap();
+        assert!(true);
+    }
+
+}

--- a/examples/theme_test_helper.rs
+++ b/examples/theme_test_helper.rs
@@ -1,6 +1,6 @@
 //! Nothing interesting here. This is just a small helper used in a test.
 
-//! This needs to be an "example" until binaries can declare separate dependencies (see https://github.com/rust-lang/cargo/issues/1982)
+//! This needs to be an "example" until binaries can declare separate dependencies (see <https://github.com/rust-lang/cargo/issues/1982>)
 
 //! See "tests/theme.rs" for more information.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -334,6 +334,7 @@
 //! [`examples/custom_filter.rs`]: https://github.com/yaahc/color-eyre/blob/master/examples/custom_filter.rs
 //! [`examples/custom_section.rs`]: https://github.com/yaahc/color-eyre/blob/master/examples/custom_section.rs
 //! [`examples/multiple_errors.rs`]: https://github.com/yaahc/color-eyre/blob/master/examples/multiple_errors.rs
+//! [`examples/cargo_tests.rs`]: https://github.com/yaahc/color-eyre/blob/master/examples/cargo_tests.rs
 #![doc(html_root_url = "https://docs.rs/color-eyre/0.6.2")]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(
@@ -458,6 +459,27 @@ pub enum ErrorKind<'a> {
 ///     # Ok(())
 /// }
 /// ```
+/// If you need to potentially call `install` multiple times, (e.g. for
+/// `cargo test`) you can use `once_cell::sync::OnceCell` to ensure that the
+/// installation is only done once.  For example:
+///
+/// ```rust
+/// use once_cell::sync::OnceCell;
+/// pub struct ColorEyreGuard(());
+/// static INIT_COLOR_EYRE: OnceCell<ColorEyreGuard> = OnceCell::new();
+
+/// pub fn init_color_eyre() {
+///     INIT_COLOR_EYRE.get_or_init(|| {
+///         color_eyre::install().expect("Failed to initialize color_eyre");
+///     ColorEyreGuard(())
+///     });
+/// }
+/// ```
+/// and then you can call init_color_eyre from multiple spots without worrying
+/// about it panicking.
+///
+/// See the [`examples/cargo_tests.rs`](https://github.com/yaahc/color-eyre/blob/master/examples/cargo_tests.rs):  for a practical example.
+
 pub fn install() -> Result<(), crate::eyre::Report> {
     config::HookBuilder::default().install()
 }


### PR DESCRIPTION
Feel free to merge. No breaking changes.