### PR TITLE
Add HelpInfo::Report and Section::{report, with_report} functions

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -80,19 +80,12 @@ impl eyre::EyreHandler for Handler {
             )?;
         }
 
-        for section in self
-            .sections
-            .iter()
-            .filter(|s| matches!(s, HelpInfo::Error(_, _)))
-        {
-            write!(separated.ready(), "{}", section)?;
-        }
-
-        for section in self
-            .sections
-            .iter()
-            .filter(|s| matches!(s, HelpInfo::Custom(_)))
-        {
+        for section in self.sections.iter().filter(|s| {
+            matches!(
+                s,
+                HelpInfo::Error(_, _) | HelpInfo::Report(_, _) | HelpInfo::Custom(_)
+            )
+        }) {
             write!(separated.ready(), "{}", section)?;
         }
 
@@ -130,11 +123,12 @@ impl eyre::EyreHandler for Handler {
         let mut h = f.header("\n");
         let mut f = h.in_progress();
 
-        for section in self
-            .sections
-            .iter()
-            .filter(|s| !matches!(s, HelpInfo::Custom(_) | HelpInfo::Error(_, _)))
-        {
+        for section in self.sections.iter().filter(|s| {
+            !matches!(
+                s,
+                HelpInfo::Custom(_) | HelpInfo::Error(_, _) | HelpInfo::Report(_, _)
+            )
+        }) {
             write!(&mut f, "{}", section)?;
             f = h.ready();
         }

--- a/src/section/mod.rs
+++ b/src/section/mod.rs
@@ -1,4 +1,5 @@
 //! Helpers for adding custom sections to error reports
+use crate::eyre::Report;
 use crate::writers::WriterExt;
 use std::fmt::{self, Display};
 
@@ -229,6 +230,12 @@ pub trait Section: crate::private::Sealed {
     where
         F: FnOnce() -> E,
         E: std::error::Error + Send + Sync + 'static;
+
+    fn report(self, report: Report) -> Self::Return;
+
+    fn with_report<F>(self, report: F) -> Self::Return
+    where
+        F: FnOnce() -> Report;
 
     /// Add a Note to an error report, to be displayed after the chain of errors.
     ///


### PR DESCRIPTION
This is a future request from #122. This way you can attach `eyre::Report` to an error (and not just types that implement std::error::Error). I haven't done any docs since I'm not sure whether this will be merged or not.