### PR TITLE
Allow suppressing spantrace for individual errors

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1062,6 +1062,7 @@ impl EyreHook {
             suppress_backtrace: false,
             #[cfg(feature = "capture-spantrace")]
             span_trace,
+            suppress_span_trace: false,
             sections: Vec::new(),
             display_env_section: self.display_env_section,
             #[cfg(feature = "track-caller")]

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -104,12 +104,14 @@ impl eyre::EyreHandler for Handler {
 
         #[cfg(feature = "capture-spantrace")]
         {
-            if let Some(span_trace) = span_trace {
-                write!(
-                    &mut separated.ready(),
-                    "{}",
-                    crate::writers::FormattedSpanTrace(span_trace)
-                )?;
+            if !self.suppress_span_trace {
+                if let Some(span_trace) = span_trace {
+                    write!(
+                        &mut separated.ready(),
+                        "{}",
+                        crate::writers::FormattedSpanTrace(span_trace)
+                    )?;
+                }
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -403,6 +403,7 @@ pub struct Handler {
     suppress_backtrace: bool,
     #[cfg(feature = "capture-spantrace")]
     span_trace: Option<SpanTrace>,
+    suppress_span_trace: bool,
     sections: Vec<HelpInfo>,
     display_env_section: bool,
     #[cfg(feature = "track-caller")]

--- a/src/section/help.rs
+++ b/src/section/help.rs
@@ -150,6 +150,14 @@ impl Section for Report {
 
         self
     }
+
+    fn suppress_span_trace(mut self, suppress: bool) -> Self::Return {
+        if let Some(handler) = self.handler_mut().downcast_mut::<crate::Handler>() {
+            handler.suppress_span_trace = suppress;
+        }
+
+        self
+    }
 }
 
 impl<T, E> Section for Result<T, E>
@@ -246,6 +254,11 @@ where
     fn suppress_backtrace(self, suppress: bool) -> Self::Return {
         self.map_err(|error| error.into())
             .map_err(|report| report.suppress_backtrace(suppress))
+    }
+
+    fn suppress_span_trace(self, suppress: bool) -> Self::Return {
+        self.map_err(|error| error.into())
+            .map_err(|report| report.suppress_span_trace(suppress))
     }
 }
 

--- a/src/section/mod.rs
+++ b/src/section/mod.rs
@@ -321,6 +321,11 @@ pub trait Section: crate::private::Sealed {
     /// Useful for reporting "unexceptional" errors for which a backtrace
     /// isn't really necessary.
     fn suppress_backtrace(self, suppress: bool) -> Self::Return;
+
+    /// Whether to suppress printing of collected spantrace (if any).
+    ///
+    /// Useful if the spantrace is already included in another section.
+    fn suppress_span_trace(self, suppress: bool) -> Self::Return;
 }
 
 /// Trait for printing a panic error message for the given PanicInfo


### PR DESCRIPTION
It is already possible to suppress the backtrace (#113), so this PR allow suppressing the spantrace, which is useful if a custom section already contains the spantrace.