### PR TITLE
Added show-backtrace feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = []
 keywords = []
 
 [features]
-default = ["track-caller", "capture-spantrace"]
+default = ["track-caller", "capture-spantrace", "show-backtrace"]
 capture-spantrace = ["tracing-error", "color-spantrace"]
 issue-url = ["url"]
 track-caller = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ default = ["track-caller", "capture-spantrace"]
 capture-spantrace = ["tracing-error", "color-spantrace"]
 issue-url = ["url"]
 track-caller = []
+show-backtrace = []
 
 [dependencies]
 eyre = "0.6.1"

--- a/src/writers.rs
+++ b/src/writers.rs
@@ -185,6 +185,7 @@ impl fmt::Display for EnvSection<'_> {
         } else {
             lib_verbosity()
         };
+        #[cfg(feature = "show-backtrace")]
         write!(f, "{}", BacktraceOmited(!self.bt_captured))?;
 
         let mut separated = HeaderWriter {
@@ -192,6 +193,7 @@ impl fmt::Display for EnvSection<'_> {
             header: &"\n",
             started: false,
         };
+        #[cfg(feature = "show-backtrace")]
         write!(&mut separated.ready(), "{}", SourceSnippets(v))?;
         #[cfg(feature = "capture-spantrace")]
         write!(
@@ -223,8 +225,10 @@ impl fmt::Display for SpanTraceOmited<'_> {
     }
 }
 
+#[cfg(feature = "show-backtrace")]
 struct BacktraceOmited(bool);
 
+#[cfg(feature = "show-backtrace")]
 impl fmt::Display for BacktraceOmited {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // Print some info on how to increase verbosity.
@@ -245,8 +249,10 @@ impl fmt::Display for BacktraceOmited {
     }
 }
 
+#[cfg(feature = "show-backtrace")]
 struct SourceSnippets(Verbosity);
 
+#[cfg(feature = "show-backtrace")]
 impl fmt::Display for SourceSnippets {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.0 <= Verbosity::Medium {


### PR DESCRIPTION
Why add it? bc someone can probably want to not have RUST_BACKTRACE env variable mentioned in their release builds, and they can disable it